### PR TITLE
Fix annotation click android

### DIFF
--- a/lib/widgets/map_widget.dart
+++ b/lib/widgets/map_widget.dart
@@ -77,7 +77,7 @@ class MapWidget extends ConsumerStatefulWidget {
 }
 
 class _MapWidgetState extends ConsumerState<MapWidget>
-    with AutomaticKeepAliveClientMixin<MapWidget> {
+    with AutomaticKeepAliveClientMixin<MapWidget> implements mbm.OnPointAnnotationClickListener {
   late mbm.MapboxMap _mapboxMap;
   ProviderSubscription<NavigationState>? _navigationListener;
   MapBoxPlace? _selectedPlace;
@@ -220,7 +220,15 @@ class _MapWidgetState extends ConsumerState<MapWidget>
           _isAvoidAnnotationClicked = true;
         });
       },
+      this,
     );
+  }
+
+  @override
+  void onPointAnnotationClick(mbm.PointAnnotation annotation) async {
+    final point = annotation.geometry;
+    final screenCoordinates = await _mapboxMap.pixelForCoordinate(point);
+    _onMapTapListener(mbm.MapContentGestureContext(touchPosition: screenCoordinates, point: point, gestureState: mbm.GestureState.ended));
   }
 
   void _loadRouteToDisplay() async {

--- a/lib/widgets/map_widget.dart
+++ b/lib/widgets/map_widget.dart
@@ -77,7 +77,8 @@ class MapWidget extends ConsumerStatefulWidget {
 }
 
 class _MapWidgetState extends ConsumerState<MapWidget>
-    with AutomaticKeepAliveClientMixin<MapWidget> implements mbm.OnPointAnnotationClickListener {
+    with AutomaticKeepAliveClientMixin<MapWidget>
+    implements mbm.OnPointAnnotationClickListener {
   late mbm.MapboxMap _mapboxMap;
   ProviderSubscription<NavigationState>? _navigationListener;
   MapBoxPlace? _selectedPlace;
@@ -228,7 +229,10 @@ class _MapWidgetState extends ConsumerState<MapWidget>
   void onPointAnnotationClick(mbm.PointAnnotation annotation) async {
     final point = annotation.geometry;
     final screenCoordinates = await _mapboxMap.pixelForCoordinate(point);
-    _onMapTapListener(mbm.MapContentGestureContext(touchPosition: screenCoordinates, point: point, gestureState: mbm.GestureState.ended));
+    _onMapTapListener(mbm.MapContentGestureContext(
+        touchPosition: screenCoordinates,
+        point: point,
+        gestureState: mbm.GestureState.ended));
   }
 
   void _loadRouteToDisplay() async {
@@ -247,7 +251,6 @@ class _MapWidgetState extends ConsumerState<MapWidget>
         _flyToRoute(_selectedRoute!, isAnimated: false);
       }
     });
-
 
     _setMapControlSettings();
   }
@@ -2222,7 +2225,8 @@ class _MapWidgetState extends ConsumerState<MapWidget>
               ),
             ),
           _showNavigationWidgets(bottomOffset, userSpeed),
-          if (_selectedRoute != null && _panelPos <= 0 &&
+          if (_selectedRoute != null &&
+              _panelPos <= 0 &&
               _viewModeContext.viewMode != ViewMode.navigation)
             Positioned(
               right: 16,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,7 +30,7 @@ environment:
 # the latest version available on pub.dev. To see which dependencies have newer
 # versions available, run `flutter pub outdated`.
 dependencies:
-  mapbox_maps_flutter: ^2.5.0
+  mapbox_maps_flutter: ^2.5.2
   auth0_flutter: ^1.4.1
   mapbox_search: ^4.2.2
   http: ^1.1.0


### PR DESCRIPTION
It seems that there's a discrepancy between iOS and Android when it comes to how annotation click events are handled. On iOS, if no annotation click handler is specified, the click event is passed on to the map. However, on Android, even when no handler is provided for the annotation, it still captures the click event, preventing the map from receiving it.

The solution is to use a dedicated click handler on Android, and pass the event manually to the function that handles map clicks.